### PR TITLE
Refactoring state publisher and controller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ros:noetic-ros-base-focal
 
-RUN apt update && apt install --yes \
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt install --yes \
     python3-catkin-tools \
     vim \
     tmux \
@@ -10,6 +10,8 @@ RUN apt update && apt install --yes \
     ros-noetic-rosserial \
     ros-noetic-rosserial-arduino \
     ros-noetic-nmea-msgs \
+    ros-noetic-rqt \
+    ros-noetic-rqt-common-plugins \
     rtklib \
     python3-tk
 

--- a/autonomous_software_pkg/src/controller.py
+++ b/autonomous_software_pkg/src/controller.py
@@ -154,7 +154,11 @@ class Controller:
             msg.pose.orientation.w,
         ]
         (roll, pitch, yaw) = tf.transformations.euler_from_quaternion(orientation_list)
-        self.current_state.angle = yaw
+
+        if yaw <= 0 and yaw >= - math.pi: # yaw in [-pi, 0]
+            self.current_state.angle = yaw
+        elif yaw > 0 and yaw <= math.pi:  # yaw in ]0, pi]
+            self.current_state.angle =  yaw - 2 * math.pi
 
         self.past_n_states.append(self.current_state)
         if len(self.past_n_states) > self.PAST_STATES_WINDOW_SIZE:

--- a/autonomous_software_pkg/src/controller.py
+++ b/autonomous_software_pkg/src/controller.py
@@ -5,6 +5,7 @@ import math
 import matplotlib.pyplot as plt
 import numpy as np
 import rospy
+import tf
 from matplotlib.animation import FuncAnimation
 
 from self_racing_car_msgs.msg import VehicleCommand
@@ -50,8 +51,8 @@ class Controller:
         # self.frequency          = rospy.get_param('~frequency', 2.0)
         # self.rate               = rospy.Rate(self.frequency)
         # self.rate_init          = rospy.Rate(1.0)   # Rate while we wait for topic
-        wp_file = "/home/antoine/workspace/2022_ws/src/utils/utm_map_generation/x_y_files/laguna_seca_track_waypoints_detail_3m.txt"
-        edges_file = "/home/antoine/workspace/2022_ws/src/utils/utm_map_generation/x_y_files/laguna_seca_track_inner_edge.txt"
+        wp_file = "/home/mattia/workspace/self_racing_rc_platform_ws/src/utils/utm_map_generation/x_y_files/laguna_seca_track_waypoints_detail_3m.txt"
+        edges_file = "/home/mattia/workspace/self_racing_rc_platform_ws/src/utils/utm_map_generation/x_y_files/laguna_seca_track_inner_edge.txt"
 
         self.PAST_STATES_WINDOW_SIZE = 10
         self.X_AXIS_LIM = 50
@@ -123,13 +124,13 @@ class Controller:
 
     def callback_current_state(self, msg):
 
-        self.current_state.x = msg.x
-        self.current_state.y = msg.y
-        self.current_state.z = msg.z
-        self.current_state.vx = msg.vx
-        self.current_state.vy = msg.vy
-        self.current_state.vz = msg.vz
-        self.current_state.angle = msg.angle
+        self.current_state.x = msg.pose.position.x
+        self.current_state.y = msg.pose.position.y
+        self.current_state.z = msg.pose.position.z
+        
+        orientation_list = [msg.pose.orientation.x, msg.pose.orientation.y, msg.pose.orientation.z, msg.pose.orientation.w]
+        (roll, pitch, yaw) = tf.transformations.euler_from_quaternion(orientation_list)
+        self.current_state.angle = yaw
 
         self.past_n_states.append(self.current_state)
         if len(self.past_n_states) > self.PAST_STATES_WINDOW_SIZE:

--- a/autonomous_software_pkg/src/controller.py
+++ b/autonomous_software_pkg/src/controller.py
@@ -5,6 +5,7 @@ import time
 
 import matplotlib.pyplot as plt
 import numpy as np
+import os
 import rospy
 import tf
 from matplotlib.animation import FuncAnimation
@@ -53,8 +54,14 @@ class Controller:
         # self.frequency          = rospy.get_param('~frequency', 2.0)
         # self.rate               = rospy.Rate(self.frequency)
         # self.rate_init          = rospy.Rate(1.0)   # Rate while we wait for topic
-        wp_file = "/home/mattia/workspace/self_racing_rc_platform_ws/src/utils/utm_map_generation/x_y_files/laguna_seca_track_waypoints_detail_3m.txt"
-        edges_file = "/home/mattia/workspace/self_racing_rc_platform_ws/src/utils/utm_map_generation/x_y_files/laguna_seca_track_inner_edge.txt"
+        x_y_folder_path = os.path.join(
+            os.path.dirname(
+                os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            ),
+            "utils/utm_map_generation/x_y_files",
+        )
+        wp_file = os.path.join(x_y_folder_path, "rex_manor_parking_lot_waypoints.txt")
+        edges_file = os.path.join(x_y_folder_path, "rex_manor_parking_lot_edges.txt")
 
         self.PAST_STATES_WINDOW_SIZE = 10
         self.X_AXIS_LIM = 30

--- a/autonomous_software_pkg/src/vehicle_state_publisher.py
+++ b/autonomous_software_pkg/src/vehicle_state_publisher.py
@@ -24,7 +24,7 @@ class VehicleStatePublisher:
         
         # Publishers
         self.pub_pose = rospy.Publisher("gps_pose", PoseStamped, queue_size=10)
-        self.pub_velocity = rospy.Publisher("gps_velocity", PoseStamped, queue_size=10)
+        self.pub_velocity = rospy.Publisher("gps_velocity", TwistStamped, queue_size=10)
 
         self.rate = rospy.Rate(1000)
 
@@ -54,7 +54,8 @@ class VehicleStatePublisher:
         track_angle_deg = rmc_msg.track
 
         """ Convert to utm coordinates"""
-        x_utm, y_utm = utm.from_latlon(latitude, longitude)
+        utm_values = utm.from_latlon(latitude, longitude)
+        x_utm, y_utm = utm_values[0], utm_values[1]
 
         """ Build the /gps_pose [PoseStamped] message """
         pose_msg = PoseStamped()


### PR DESCRIPTION
This PR include some of the initial steps of our code refactoring.

1. **Vehicle state publisher**
- Subscribes to a gprmc message instead of our custom type RmcNmea
- Publishes a PoseStamped and TwistStamped instead of our custom type VehicleState
- Publishes a tf world to car 
- The logic for the yaw angle is the same as before, to not change the controller's behavior. But a suggestion of possible improvement was included in the code. We might see a difference in visualization between matplotlib and the tf in rviz

3. **Controller**
- Subscribes to PoseStamped instead of VehicleState
- The code logic was not changed, except the subscribing part. A new class State had to be created to replace VehicleState and not change the rest of the code.