### PR TITLE
Make gps publisher node use nmea_msgs/Gprmc message type

### DIFF
--- a/autonomous_software_pkg/src/rtk_gps_serial_reader.py
+++ b/autonomous_software_pkg/src/rtk_gps_serial_reader.py
@@ -37,32 +37,17 @@ class RtkGpsSerialReader:
 
             # If data received, print it
             if serial_data:
-                print("Received data from serial port: ", serial_data)
-
                 # uncomment to handle RMC
                 if "GNRMC" in serial_data:
-                    print(serial_data)
                     parsed_msg = NMEAReader.parse(serial_data)
                     print(parsed_msg)
-                    # print("Lat: {}, Lon: {}".format(parsed_msg.lat, parsed_msg.lon))
-                    # print(parsed_msg)
                     self.publish_nmea_sentence_rmc(parsed_msg)
-
-                # uncomment to handle GGA
-                # NOTE interestingly there is no velocity info in this message
-                # if('GNGGA' in serial_data):
-                #     print(serial_data)
-                #     parsed_msg = NMEAReader.parse(serial_data)
-                #     print(parsed_msg)
-                #     # print("Lat: {}, Lon: {}".format(parsed_msg.lat, parsed_msg.lon))
-                #     # print(parsed_msg)
-                #     self.publish_nmea_sentence_gga(parsed_msg)
 
             self.rate.sleep()
 
     def publish_nmea_sentence_rmc(self, parsed_msg):
         """
-        TODO
+        Formats the parsed line from the serial into a nmea_msgs/Gprmc message and publishes it
         """
         # we need to construct the date and time by hand
         date_time_string = f"{parsed_msg.date}_{parsed_msg.time}"
@@ -80,19 +65,15 @@ class RtkGpsSerialReader:
         msg.lon_dir = parsed_msg.EW
         msg.speed = parsed_msg.spd
         msg.track = parsed_msg.cog
-        msg.date = parsed_msg.date
-        msg.mag_var = parsed_msg.mv
+        msg.date = parsed_msg.date.strftime("%Y-%m-%d")
+        try:
+            msg.mag_var = float(parsed_msg.mv)
+        except Exception:
+            msg.mag_var = -1
         msg.mag_var_direction = parsed_msg.mvEW
         msg.mode_indicator = parsed_msg.posMode
 
         self.pub.publish(msg)
-
-    def publish_nmea_sentence_gga(self, parsed_msg):
-        """
-        TODO
-        """
-        # TODO
-        pass
 
 
 if __name__ == "__main__":

--- a/autonomous_software_pkg/src/rtk_gps_serial_reader.py
+++ b/autonomous_software_pkg/src/rtk_gps_serial_reader.py
@@ -1,10 +1,11 @@
 #!/usr/bin/python3
 
+import datetime as dt
 import rospy
 import serial
 from pynmeagps import NMEAReader
 
-from self_racing_car_msgs.msg import RmcNmea
+from nmea_msgs.msg import Gprmc
 
 SERIAL_PORT = "/dev/ttyACM0"
 BAUD_RATE = 9600
@@ -21,7 +22,7 @@ class RtkGpsSerialReader:
     def __init__(self):
         self.serial_port = serial.Serial(SERIAL_PORT, baudrate=BAUD_RATE, timeout=1)
 
-        self.pub = rospy.Publisher("gps_info", RmcNmea, queue_size=10)
+        self.pub = rospy.Publisher("gps_pose", Gprmc, queue_size=10)
 
         rospy.init_node("rtk_gps_serial_reader", anonymous=True)
 
@@ -63,15 +64,26 @@ class RtkGpsSerialReader:
         """
         TODO
         """
-        msg = RmcNmea()
+        # we need to construct the date and time by hand
+        date_time_string = f"{parsed_msg.date}_{parsed_msg.time}"
+        if "." in date_time_string:
+            dt_object = dt.datetime.strptime(date_time_string, "%Y-%m-%d_%H:%M:%S.%f")
+        else:
+            dt_object = dt.datetime.strptime(date_time_string, "%Y-%m-%d_%H:%M:%S")
+
+        msg = Gprmc()
         msg.header.stamp = rospy.Time.now()
-        msg.timestamp_utc = 0  # TODO replace with self.gps.timestamp_utc but needs to be converted from time.struct_time
-        msg.latitude = parsed_msg.lat
-        msg.longitude = parsed_msg.lon
-        msg.speed_knots = parsed_msg.spd
-        msg.track_angle_deg = (
-            parsed_msg.cog
-        )  # NOTE: what is cog and how to get track angle?
+        msg.utc_seconds = dt_object.replace(tzinfo=dt.timezone.utc).timestamp()
+        msg.lat = parsed_msg.lat
+        msg.lon = parsed_msg.lon
+        msg.lat_dir = parsed_msg.NS
+        msg.lon_dir = parsed_msg.EW
+        msg.speed = parsed_msg.spd
+        msg.track = parsed_msg.cog
+        msg.date = parsed_msg.date
+        msg.mag_var = parsed_msg.mv
+        msg.mag_var_direction = parsed_msg.mvEW
+        msg.mode_indicator = parsed_msg.posMode
 
         self.pub.publish(msg)
 

--- a/autonomous_software_pkg/src/rtk_gps_serial_reader.py
+++ b/autonomous_software_pkg/src/rtk_gps_serial_reader.py
@@ -22,7 +22,7 @@ class RtkGpsSerialReader:
     def __init__(self):
         self.serial_port = serial.Serial(SERIAL_PORT, baudrate=BAUD_RATE, timeout=1)
 
-        self.pub = rospy.Publisher("gps_pose", Gprmc, queue_size=10)
+        self.pub = rospy.Publisher("gps_info", Gprmc, queue_size=10)
 
         rospy.init_node("rtk_gps_serial_reader", anonymous=True)
 


### PR DESCRIPTION
Getting rid of our custom message type and using nmea_msgs/Gprmc instead.

Tested by recording running the adapted vehicle_state_publisher -> gets expected input.