### PR TITLE
Correct yaw angle

### DIFF
--- a/autonomous_software_pkg/src/lateral_controller.py
+++ b/autonomous_software_pkg/src/lateral_controller.py
@@ -1,5 +1,4 @@
 from geometry_msgs.msg import PoseStamped
-import numpy as np
 import rospy
 from std_msgs.msg import Float32, Float64
 import tf
@@ -77,10 +76,7 @@ class LateralController:
         ]
         (roll, pitch, yaw) = tf.transformations.euler_from_quaternion(orientation_list)
 
-        if yaw <= 0 and yaw >= -np.pi:  # yaw in [-pi, 0]
-            self.current_state.angle = yaw
-        elif yaw > 0 and yaw <= np.pi:  # yaw in ]0, pi]
-            self.current_state.angle = yaw - 2 * np.pi
+        self.current_state.angle = yaw
 
     def target_curvature_callback(self, msg: Float64):
         """

--- a/autonomous_software_pkg/src/vehicle_state_publisher.py
+++ b/autonomous_software_pkg/src/vehicle_state_publisher.py
@@ -72,12 +72,8 @@ class VehicleStatePublisher:
         pose_msg.pose.position.y = y_utm
         pose_msg.pose.position.z = 0
 
-        # yaw_rad = (math.pi / 2) - track_angle_deg * math.pi / 180 # Radians. Origin is horizontal axis
-
-        # This is the angle we are using for now and for which the controller works fine. Not updating it
-        # right now, but later we might switch it to the version above, which has its origin on the horizontal axis,
-        # which should be a little more standard. The speed projection might not he good at the moment.
-        yaw_rad = -track_angle_deg * math.pi / 180
+        # Yaw angle [radians]. Origin is horizontal axis. Counter clockwise
+        yaw_rad = (math.pi / 2) - track_angle_deg * math.pi / 180
 
         # Convert to quaternions
         quaternion = tf.transformations.quaternion_from_euler(0, 0, yaw_rad)

--- a/autonomous_software_pkg/src/vehicle_state_publisher.py
+++ b/autonomous_software_pkg/src/vehicle_state_publisher.py
@@ -73,6 +73,7 @@ class VehicleStatePublisher:
         pose_msg.pose.position.z = 0
 
         # Yaw angle [radians]. Origin is horizontal axis. Counter clockwise
+        # Offsetting by pi/2 compared to what is provided by the GPS, because the GPS track angle origin is the vertical axis
         yaw_rad = (math.pi / 2) - track_angle_deg * math.pi / 180
 
         # Convert to quaternions

--- a/geometry_utils/src/geometry_utils/geometry_utils.py
+++ b/geometry_utils/src/geometry_utils/geometry_utils.py
@@ -40,18 +40,21 @@ def compute_curvature(current_state: State, target_state: State):
     """
     # Computing the norm of the curvature
     orthogonal_vector = [
-        -np.sin(current_state.angle + np.pi / 2),
-        np.cos(current_state.angle + np.pi / 2),
+        -np.sin(current_state.angle),
+        np.cos(current_state.angle),
     ]
     d = distance_point_to_line(current_state, orthogonal_vector, target_state)
     D = plane_distance(current_state, target_state)
+    print("-------")
+    print("d: ", d)
+    print("D: ", D)
     curvature_norm = 2 * np.sqrt(D**2 - d**2) / D**2
 
     # Computing the sign of the curvature
     car_direction_vector = np.array(
         [
-            np.cos(current_state.angle + np.pi / 2),
-            np.sin(current_state.angle + np.pi / 2),
+            np.cos(current_state.angle),
+            np.sin(current_state.angle),
         ]
     )
     target_direction_vector = np.array(

--- a/geometry_utils/src/geometry_utils/geometry_utils.py
+++ b/geometry_utils/src/geometry_utils/geometry_utils.py
@@ -45,9 +45,7 @@ def compute_curvature(current_state: State, target_state: State):
     ]
     d = distance_point_to_line(current_state, orthogonal_vector, target_state)
     D = plane_distance(current_state, target_state)
-    print("-------")
-    print("d: ", d)
-    print("D: ", D)
+
     curvature_norm = 2 * np.sqrt(D**2 - d**2) / D**2
 
     # Computing the sign of the curvature


### PR DESCRIPTION
Currently the yaw angle being used in the system is anti-clockwise positive and its origin is the vertical axis. Although its not particularly a problem, most rotations and angles in ROS use a different system. Angles are usually represented with their origin being the horizontal axis.

This PR corrects the yaw angle to make things a little easier when working with / displaying angles as well as using existing functions in the tf library.

The changes were validated using the rosbag called **rosbag antoine_and_mattia_branches_merged_parking_lot_2023-09-09-20-49-22.bag** and plotting the topic _/steering_pmw_cmd_ before and after the changes. As seen from the two plots below, the output steering command is the same.

**Before the changes**
![master_diagram](https://github.com/roux-antoine/self-racing-rc-platform/assets/43971634/a28f2239-7f14-4545-b861-71587e53150a)

**After the changes**
![diagram_after_changes](https://github.com/roux-antoine/self-racing-rc-platform/assets/43971634/8a6b17a9-cbdf-43a5-9333-07070e793c89)

**Note**: The x-axis is representative of the time the messages were published but the origin is the time at which the foxglove app (for visualization) was started. Therefore not representative of a potential delay generated by the changes in the PR.

