### PR TITLE
Move ComputeCurvature to the TargetGenerator

### DIFF
--- a/autonomous_software_pkg/src/target_generator.py
+++ b/autonomous_software_pkg/src/target_generator.py
@@ -292,7 +292,7 @@ class TargetGenerator:
         curvature_msg = Float64()
         curvature_msg.data = curvature
 
-        self.target_curvature_pub(curvature_msg)
+        self.target_curvature_pub.publish(curvature_msg)
 
 
 if __name__ == "__main__":

--- a/autonomous_software_pkg/src/target_generator.py
+++ b/autonomous_software_pkg/src/target_generator.py
@@ -12,6 +12,7 @@ from geometry_utils.geometry_utils import (
     compute_curvature,
 )
 from std_msgs.msg import Float64
+import tf
 
 
 """
@@ -104,6 +105,18 @@ class TargetGenerator:
             """Read subscribed message"""
             self.current_state.x = pose_msg.pose.position.x
             self.current_state.y = pose_msg.pose.position.y
+
+            orientation_list = [
+                pose_msg.pose.orientation.x,
+                pose_msg.pose.orientation.y,
+                pose_msg.pose.orientation.z,
+                pose_msg.pose.orientation.w,
+            ]
+            (roll, pitch, yaw) = tf.transformations.euler_from_quaternion(
+                orientation_list
+            )
+
+            self.current_state.angle = yaw
 
             """ Get Next waypoint - First waypoint further than the lookahead distance """
             nextWaypointId = self.getNextWaypoint()


### PR DESCRIPTION
This PR moves the call of the ComputeCurvature function from the lateral_controller to the target_generator. 
This change is implemented for:
- Having a more  uniform output of target_generator (it now publishes a target curvature and a target speed)
- Making the implementation of a vehicle simulator simpler, by defining a clear limit between what's purely software related and what's more related to the controller's implementation (and that we don't necessarily want to simulate yet) 

The changes were validated using the rosbag called rosbag antoine_and_mattia_branches_merged_parking_lot_2023-09-09-20-49-22.bag and plotting the topic /steering_pmw_cmd before and after the changes. As seen from the two plots below, the output steering command is the same.
Before the changes
![master_diagram](https://github.com/roux-antoine/self-racing-rc-platform/assets/43971634/fddef816-85c6-495e-b989-428c3bcf7022)
After the changes
![steering_v4](https://github.com/roux-antoine/self-racing-rc-platform/assets/43971634/0b61558c-ddbe-4386-9710-68b7d845b2d1)
Note: The x-axis is representative of the time the messages were published but the origin is the time at which the foxglove app (for visualization) was started. Therefore not representative of a potential delay generated by the changes in the PR.