### PR TITLE
Correct speed projection and speed callback

### DIFF
--- a/autonomous_software_pkg/src/longitudinal_controller.py
+++ b/autonomous_software_pkg/src/longitudinal_controller.py
@@ -34,7 +34,7 @@ class LongitudinalController:
             queue_size=10,
         )
 
-    def target_velocity_callback(self, msg: Float32):
+    def target_velocity_callback(self, msg: TwistStamped):
         """
         The most basic controller for now: send a constant value
         """

--- a/autonomous_software_pkg/src/longitudinal_controller.py
+++ b/autonomous_software_pkg/src/longitudinal_controller.py
@@ -24,7 +24,7 @@ class LongitudinalController:
         rospy.Subscriber(
             target_velocity_topic_name,
             TwistStamped,
-            self.target_point_callback,
+            self.target_velocity_callback,
         )
 
         # Publishers
@@ -34,7 +34,7 @@ class LongitudinalController:
             queue_size=10,
         )
 
-    def target_point_callback(self, msg: Float32):
+    def target_velocity_callback(self, msg: Float32):
         """
         The most basic controller for now: send a constant value
         """

--- a/autonomous_software_pkg/src/vehicle_state_publisher.py
+++ b/autonomous_software_pkg/src/vehicle_state_publisher.py
@@ -88,9 +88,8 @@ class VehicleStatePublisher:
 
         vel_msg = TwistStamped()
         vel_msg.header.stamp = rospy.Time.now()
-        vel_msg.header.frame_id = "world"
-        vel_msg.twist.linear.x = speed_mps * math.cos(yaw_rad)
-        vel_msg.twist.linear.y = speed_mps * math.sin(yaw_rad)
+        vel_msg.header.frame_id = "car"
+        vel_msg.twist.linear.x = speed_mps
 
         """ Publish /tf """
         # Publish the tf between 'world' and 'car' for visualization purposes.


### PR DESCRIPTION
This PR implements the following changes:

**vehicle_state_publisher**:
- Removes the speed projection into the vehicle's x and y axis and instead just uses the x axis

**longitudinal_controller**:
- Corrects the current_velocity callback's name
- Corrects the current_velocity callback's input type