### PR TITLE
Fixe TypeError bug when vehicle is at last waypoint

### DIFF
--- a/autonomous_software_pkg/src/target_generator.py
+++ b/autonomous_software_pkg/src/target_generator.py
@@ -185,7 +185,7 @@ class TargetGenerator:
         # in this case, we return the last waypoint
         rospy.logwarn("All waypoints considered are within the lookahead distance")
         # TODO change: implement slowdown
-        return self.waypoints[-1].id
+        return self.waypoints.waypoints[-1].id
 
     def getTargetPoint(self, nextWaypointId: int):
         """

--- a/autonomous_software_pkg/src/target_generator.py
+++ b/autonomous_software_pkg/src/target_generator.py
@@ -168,7 +168,7 @@ class TargetGenerator:
         if id_closest_wp is None:
             rospy.logfatal("No closest waypoint found")
             # TODO: Improve the logic
-            return self.waypoints[-1].id
+            return self.waypoints.waypoints[-1].id
 
         """ Iterate through all the waypoints starting from the closest + 1. Return the first further than lookahead """
         for wp in self.waypoints.waypoints[id_closest_wp + 1 :]:


### PR DESCRIPTION
This PR fixes a bug that happens when the vehicle reaches the last waypoint and the following line is called:
```python
# If we are here, it means that all the waypoints behind the closest one are inside the lookahead distance
# in this case, we return the last waypoint
return self.waypoints[-1].id
```
Which triggers a TypeError because self.waypoints is not subscriptable.


The way we handle the situation where the vehicle reaches the last waypoint is not ideal but at least now the script won't fail because of that error.