### PR TITLE
Serial devices udev rules

### DIFF
--- a/autonomy_software/localization_pkg/src/rtk_gps_serial_reader.py
+++ b/autonomy_software/localization_pkg/src/rtk_gps_serial_reader.py
@@ -7,7 +7,7 @@ from pynmeagps import NMEAReader
 
 from nmea_msgs.msg import Gprmc
 
-SERIAL_PORT = "/dev/ttyACM1"
+SERIAL_PORT = "/dev/gps"
 BAUD_RATE = 9600
 
 """

--- a/firmware/arduino_pkg/README.md
+++ b/firmware/arduino_pkg/README.md
@@ -32,4 +32,4 @@ Then run: `catkin build arduino_pkg`
 # Running the code
 
 * Start roscore if needed
-* Initiate the "bridge": `rosrun rosserial_python serial_node.py _port:=/dev/ttyACM0 _baud:=57600` (or whatever the port and baudrate are)
+* Initiate the "bridge": `rosrun rosserial_python serial_node.py _port:=/dev/arduino _baud:=57600` (or whatever the port and baudrate are)

--- a/firmware/arduino_pkg/firmware/CMakeLists.txt
+++ b/firmware/arduino_pkg/firmware/CMakeLists.txt
@@ -13,6 +13,6 @@ add_definitions(-DUSB_CON)
 generate_arduino_firmware(arduino_node
   SRCS arduino_node.cpp ${ROS_LIB_DIR}/time.cpp
   BOARD mega2560
-  PORT /dev/ttyACM0
-  # SERIAL picocom /dev/ttyACM0  # found in https://github.com/ros-drivers/rosserial/issues/459, seems to work without
+  PORT /dev/arduino
+  # SERIAL picocom /dev/arduino  # found in https://github.com/ros-drivers/rosserial/issues/459, seems to work without
 )

--- a/start_scripts/README.md
+++ b/start_scripts/README.md
@@ -3,12 +3,12 @@
 ## start_all_2022.sh
 
 Start script adapted from Self Racing Cars 2022, to be used with the Adafruit GPS module
-Make sure that the GPS is on /dev/ttyUSB0
-Make sure that the Arduino is on /dev/ttyACM0
+Make sure that the GPS is on /dev/gps
+Make sure that the Arduino is on /dev/arduino
 
 ## start_all_rtk.sh
 
 Start script to be used with the Ardusimple GPS module
 Make sure that the device /dev/ttyUSB0 is available (to send the RTCM correction data)
-Make sure that the GPS is on /dev/ttyACM0
-Make sure that the Arduino is on /dev/ttyACM1
+Make sure that the GPS is on /dev/gps
+Make sure that the Arduino is on /dev/arduino

--- a/start_scripts/start_all_rtk.sh
+++ b/start_scripts/start_all_rtk.sh
@@ -104,7 +104,7 @@ tmux send-keys "rosrun controllers_pkg longitudinal_controller.py _longitudinal_
 tmux select-pane -t 4
 tmux send-keys "cd '$ABS_SCRIPT_DIR/../firmware'" C-m
 tmux send-keys "source $setup_bash_path" C-m
-tmux send-keys "rosrun rosserial_python serial_node.py _port:=/dev/ttyACM0 _baud:=57600" C-m
+tmux send-keys "rosrun rosserial_python serial_node.py _port:=/dev/arduino _baud:=57600" C-m
 
 # rostopic echo /arduino_logging
 tmux select-pane -t 5

--- a/utils/udev/98-gps.rules
+++ b/utils/udev/98-gps.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1546", ATTRS{idProduct}=="01a9", SYMLINK+="gps"

--- a/utils/udev/99-arduino.rules
+++ b/utils/udev/99-arduino.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="tty", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="0042", SYMLINK+="arduino"

--- a/utils/udev/Readme.md
+++ b/utils/udev/Readme.md
@@ -1,0 +1,16 @@
+# Udev rules
+
+Udev is a device manager for linux. We use it to trigger an event when a new device is plugged in. In our case, we use it to always give the same name to serial devices whose names are hardcoded somewhere else in the code.
+
+## Example
+```console
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1546", ATTRS{idProduct}=="01a9", SYMLINK+="gps"
+```
+## Usage
+
+1. Copy and paste the .rules files in  /etc/udev/rules.d/
+2. Reload and apply the rules using:
+```console
+$ sudo udevadm control --reload-rules
+$ sudo udevadm trigger
+```


### PR DESCRIPTION
Adding guidelines to add udev rules so our serial devices always have the same name.

**Question**
What about the port through which we send the RTCM correction data? Do we need to change it or is it always /dev/ttyUSBB0?