### PR TITLE
Update GNSS corrections caster after NTRIP migration

### DIFF
--- a/autonomy_software/localization_pkg/src/rtcm_corr_serial_pub.sh
+++ b/autonomy_software/localization_pkg/src/rtcm_corr_serial_pub.sh
@@ -1,7 +1,7 @@
 USERNAME=${UNAVCO_USERNAME} # make sure that this env var is being set in your bashrc
 PASSWORD=${UNAVCO_PASSWORD} # make sure that this env var is being set in your bashrc
 PORT=2101
-MOUNT_POINT=P178_RTCM3
+MOUNT_POINT=P178_RTCM3P3
 SERIAL_PORT=ttyUSB0
 BAUD_RATE=115200
 
@@ -16,6 +16,6 @@ echo " ------------------------ "
 # TODO: Check if serial port is available
 # TODO: Exception handling?
 
-str2str -in ntrip://$USERNAME:$PASSWORD@rtgpsout.unavco.org:$PORT/$MOUNT_POINT -out serial://$SERIAL_PORT:$BAUD_RATE:8:n:1
+str2str -in "ntrip://${USERNAME}:${PASSWORD}@ntrip.earthscope.org:${PORT}/${MOUNT_POINT}" -out serial://${SERIAL_PORT}:${BAUD_RATE}:8:n:1
 
-# str2str -in ntrip://$USERNAME:$PASSWORD@rtgpsout.unavco.org:$PORT/$MOUNT_POINT -out temp.log
+# str2str -in "ntrip://${USERNAME}:${PASSWORD}@ntrip.earthscope.org:${PORT}/${MOUNT_POINT}" -out temp.log


### PR DESCRIPTION
On July 29, Earthscope is updating its legacy NTRIP caster to a new system. See https://www.earthscope.org/news/transition-to-new-real-time-gnss-streaming-platform/


Changes:

- Re-registration required. Existing username and passwords will not work
- Hostname: [ntrip.earthscope.org](http://ntrip.earthscope.org/) (replacing [rtgpsout.earthscope.org](http://rtgpsout.earthscope.org/))
- Format Support: RTCM 3.3 and BINEX (RTCM 3.1 will be discontinued)
- New Mountpoint Format: {FCID}_RTCM3P3 (not {FCID}_RTCM3)

I'm updating the bash command to transfer the corrections according to the guidelines, and I put the new username and password in the framework's bashrc. 
Tested it on the framework, seems to be working fine. 