### PR TITLE
Unify logic for current vehicle models + try new fitting technique

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ venv
 .DS_Store
 __pycache__
 utils/geometry_utils_pkg/src/geometry_utils_pkg.egg-info
+bags
+.catkin_tools
+.cache

--- a/autonomy_software/controllers_pkg/src/controllers_pkg/lateral_controller.py
+++ b/autonomy_software/controllers_pkg/src/controllers_pkg/lateral_controller.py
@@ -44,6 +44,7 @@ class LateralController:
         self.target_point_state = None
         self.rate = rospy.Rate(rate)
         self.current_velocity = 0
+        self.last_steering_cmd = None
 
         # Subscribers
         rospy.Subscriber(
@@ -86,6 +87,8 @@ class LateralController:
         self.STEERING_IDLE_PWM = config["steering_idle_pwm"]
         self.STEERING_MAX_PWM = config["steering_max_pwm"]
         self.STEERING_MIN_PWM = config["steering_min_pwm"]
+        self.delay_compensation_enabled = config["delay_compensation_enabled"]
+        self.actuation_delay_s = config["actuation_delay_s"]
         return config
 
     def current_pose_callback(self, msg: PoseStamped):
@@ -131,9 +134,26 @@ class LateralController:
                 self.rate.sleep()
                 continue
 
-            # Compute curvature from current pose and target point
+            # Optionally predict future state to compensate for actuation delay
+            if self.delay_compensation_enabled and self.last_steering_cmd is not None:
+                predictor = type(self.vehicle_model)()
+                predictor.init(
+                    x=self.current_state.x,
+                    y=self.current_state.y,
+                    vx=self.current_velocity,
+                    angle=self.current_state.angle,
+                )
+                predictor.step(
+                    dt=self.actuation_delay_s,
+                    cmd_steering=self.last_steering_cmd,
+                )
+                reference_state = predictor.states[-1]
+            else:
+                reference_state = self.current_state
+
+            # Compute curvature from reference state and target point
             curvature = compute_curvature(
-                current_state=self.current_state,
+                current_state=reference_state,
                 target_state=self.target_point_state,
             )
 
@@ -158,6 +178,9 @@ class LateralController:
                 steering_command_pwm = self.STEERING_MAX_PWM
             elif steering_command_pwm < self.STEERING_MIN_PWM:
                 steering_command_pwm = self.STEERING_MIN_PWM
+
+            # Store for next iteration's delay compensation
+            self.last_steering_cmd = steering_command_pwm
 
             # Publish steering output
             self.steering_cmd_pub.publish(steering_command_pwm)

--- a/autonomy_software/dynamic_reconfigure_pkg/cfg/lateral_controller.cfg
+++ b/autonomy_software/dynamic_reconfigure_pkg/cfg/lateral_controller.cfg
@@ -8,5 +8,7 @@ gen = ParameterGenerator()
 gen.add("steering_idle_pwm", double_t, 1, "PWM value of the idle of the steering", 90, 0, 180)
 gen.add("steering_max_pwm", double_t, 1, "PWM value of the max of the steering", 116, 0, 180)  # 118 - 2
 gen.add("steering_min_pwm", double_t, 1, "PWM value of the min of the steering", 64, 0, 180) # 62 + 2
+gen.add("delay_compensation_enabled", bool_t, 1, "Enable actuation delay compensation", False)
+gen.add("actuation_delay_s", double_t, 1, "Actuation delay to compensate for (seconds)", 0.1, 0.0, 0.5)
 
 exit(gen.generate(PACKAGE, "dynamic_reconfigure_pkg", "lateral_controller"))

--- a/autonomy_software/vehicle_models_pkg/src/vehicle_models_pkg/vehicle_models.py
+++ b/autonomy_software/vehicle_models_pkg/src/vehicle_models_pkg/vehicle_models.py
@@ -269,10 +269,10 @@ class CarModelBicycleV3(CarModelBicycleV2):
 
             # If speed is below the minimum, use the minimum speed's coefficient
             if speed <= sorted_speeds[0]:
-                coeff = self.SPEEDS_TO_COEFF_MAPPING[sorted_speeds[0]]
+                coeff = self.SPEEDS_TO_COEFF_MAPPING[sorted_speeds[0]] * speed
             # If speed is above the maximum, use the maximum speed's coefficient
             elif speed >= sorted_speeds[-1]:
-                coeff = self.SPEEDS_TO_COEFF_MAPPING[sorted_speeds[-1]]
+                coeff = self.SPEEDS_TO_COEFF_MAPPING[sorted_speeds[-1]] * speed
             else:
                 # Find the two speeds that bound the current speed
                 for i in range(len(sorted_speeds) - 1):
@@ -286,7 +286,9 @@ class CarModelBicycleV3(CarModelBicycleV2):
 
                         # Weight factor: 0 means use lower_coeff, 1 means use upper_coeff
                         weight = (speed - lower_speed) / (upper_speed - lower_speed)
-                        coeff = lower_coeff * (1 - weight) + upper_coeff * weight
+                        coeff = (
+                            lower_coeff * (1 - weight) + upper_coeff * weight
+                        ) * speed
                         break
 
         return coeff

--- a/autonomy_software/vehicle_models_pkg/src/vehicle_models_pkg/vehicle_models.py
+++ b/autonomy_software/vehicle_models_pkg/src/vehicle_models_pkg/vehicle_models.py
@@ -267,11 +267,28 @@ class CarModelBicycleV3(CarModelBicycleSpeedToParam):
     }
 
 
+class CarModelBicycleV3B(CarModelBicycleSpeedToParam):
+    """
+    Same as V3, but using the bags from the 2025-08-24 Cañada College testing session
+    """
+
+    SPEEDS_TO_PARAM_MAPPING: dict = {
+        2: 15.46,
+        3: 10.22,
+        4: 8.90,
+        5: 9.42,
+        6: 10.13,
+        7: 10.44,
+    }
+
+
 class CarModelBicycleV4(CarModelBicycleSpeedToParam):
     """
     Similar to V2 and V3, but estimated using the script trajectory_based_identification.py, which optimizes the parameters based on the
     entire trajectory and not just steady-state circle fitting.
-    The bags were from the 20250824 Cañada College testing session
+    The bags were from the 2025-08-24 Cañada College testing session
+
+    WARNING: I think these params won't work IRL, because they have an explicit reliance on the yaw_angles at each position. Which we know are very imprecise.
     """
 
     SPEEDS_TO_PARAM_MAPPING: dict = {

--- a/autonomy_software/vehicle_models_pkg/src/vehicle_models_pkg/vehicle_models.py
+++ b/autonomy_software/vehicle_models_pkg/src/vehicle_models_pkg/vehicle_models.py
@@ -251,14 +251,32 @@ class CarModelBicycleV2(CarModelBicycleSpeedToParam):
 
 class CarModelBicycleV3(CarModelBicycleSpeedToParam):
     """
-    Similar to V2, but with updated params based on the 2025-07-20 San Mateo bagfiles (still steady-state circle fitting)
+    Similar to V2, they were estimated from steady-state circle fitting, but using scripts in the folder steering_param_identification
+    The bags were from the 2025-07-20 San Mateo testing session
     """
 
     SPEEDS_TO_PARAM_MAPPING: dict = {
-        2: 12.67852795,
-        3: 12.29078091,
-        4: 10.12400495,
-        5: 9.71443423,
-        6: 9.55109679,
-        7: 10.15111903,
+        2: 12.67,
+        3: 12.29,
+        4: 10.12,
+        5: 9.71,
+        6: 9.55,
+        7: 10.15,
+    }
+
+
+class CarModelBicycleV4(CarModelBicycleSpeedToParam):
+    """
+    Similar to V2 and V3, but estimted using the script trajectory_based_identification.py, which optimizes the parameters based on the
+    entire trajectory and not just steady-state circle fitting.
+    The bags were from the 20250824 Cañada College testing session
+    """
+
+    SPEEDS_TO_PARAM_MAPPING: dict = {
+        2.0: 4.31,
+        3.0: 2.91,
+        4.0: 2.34,
+        5.0: 2.80,
+        6.0: 2.20,
+        7.0: 4.24,
     }

--- a/autonomy_software/vehicle_models_pkg/src/vehicle_models_pkg/vehicle_models.py
+++ b/autonomy_software/vehicle_models_pkg/src/vehicle_models_pkg/vehicle_models.py
@@ -177,6 +177,8 @@ class CarModelBicycleSpeedToParam(CarModelBicyclePure):
 
     Meaning models of the form: radius = coeff / steering_diff , where coeff is obtained by interpolating the SPEEDS_TO_PARAM_MAPPING
     dict based on the current speed.
+
+    WARNING: coeff != params --> The coeff is the value used to compute the radius, while the params are the values used to compute the coeff
     """
 
     SPEEDS_TO_PARAM_MAPPING: dict = {}
@@ -242,10 +244,10 @@ class CarModelBicycleV2(CarModelBicycleSpeedToParam):
     They were estimated from steady-state circle fitting, using scripts in the folder steering_param_identification_old
     """
 
-    SPEEDS_TO_PARAM_MAPPING: dict = {  # here, params were computed as: steering_diff * radius of circle at the given speed
-        1.5: 27 * 1.25,
-        5: 24 * 2.3,
-        8: 26 * 4,
+    SPEEDS_TO_PARAM_MAPPING: dict = {
+        1.5: 27 * 1.25 / 1.5,
+        5: 24 * 2.3 / 5,
+        8: 26 * 4 / 8,
     }
 
 
@@ -267,7 +269,7 @@ class CarModelBicycleV3(CarModelBicycleSpeedToParam):
 
 class CarModelBicycleV4(CarModelBicycleSpeedToParam):
     """
-    Similar to V2 and V3, but estimted using the script trajectory_based_identification.py, which optimizes the parameters based on the
+    Similar to V2 and V3, but estimated using the script trajectory_based_identification.py, which optimizes the parameters based on the
     entire trajectory and not just steady-state circle fitting.
     The bags were from the 20250824 Cañada College testing session
     """

--- a/autonomy_software/vehicle_models_pkg/src/vehicle_models_pkg/vehicle_models.py
+++ b/autonomy_software/vehicle_models_pkg/src/vehicle_models_pkg/vehicle_models.py
@@ -172,44 +172,47 @@ class CarModelBicycleV1(CarModelBicyclePure):
         ) * np.arctan(WHEELBASE / radius)
 
 
-class CarModelBicycleV2(CarModelBicyclePure):
-    """Models the car behavior as a kinematic bicycle model.
+class CarModelBicycleSpeedToParam(CarModelBicyclePure):
+    """Base class for models that assume that the car is moving in a circular path, with a constant radius determined by the steering command,
 
-    The model assumes that the car is moving in a circular path, with a constant radius determined by the steering command,
-    with the first attempt at parameter fitting (2023-2024), i.e. the V2 model.
+    Meaning models of the form: radius = coeff / steering_diff , where coeff is obtained by interpolating the SPEEDS_TO_PARAM_MAPPING
+    dict based on the current speed.
     """
 
-    UPPER_BOUND_REGION_1: float = 1.5  # m/s
-    UPPER_BOUND_REGION_2: float = 5  # m/s
-    UPPER_BOUND_REGION_3: float = 8  # m/s
-    # Coeffs are computed as: steering_diff * radius of circle at the given speed
-    COEFF_REGION_1: float = 27 * 1.25
-    COEFF_REGION_2: float = 24 * 2.3
-    COEFF_REGION_3: float = 26 * 4
+    SPEEDS_TO_PARAM_MAPPING: dict = {}
 
     def _compute_coefficient(self, speed: float) -> float:
-        """Compute the coefficient used to compute the required turning radius, see model description for more details."""
+        """Compute the coefficient by interpolating the speed-to-param mapping and multiplying by the speed.
+
+        Meaning: coeff = param(speed) * speed, where param(speed) is obtained by interpolating the SPEEDS_TO_PARAM_MAPPING dict based on the current speed.
+
+        """
+        if not self.SPEEDS_TO_PARAM_MAPPING:
+            raise ValueError("SPEEDS_TO_PARAM_MAPPING cannot be empty!")
 
         if speed < 0:
             raise ValueError("Speed cannot be negative!")
         if speed == 0:
-            coeff = self.VERY_LARGE_RADIUS
-        elif 0 < speed <= self.UPPER_BOUND_REGION_1:
-            coeff = self.COEFF_REGION_1
-        elif self.UPPER_BOUND_REGION_1 < speed <= self.UPPER_BOUND_REGION_2:
-            coeff = self.COEFF_REGION_1 + (speed - self.UPPER_BOUND_REGION_1) * (
-                self.COEFF_REGION_2 - self.COEFF_REGION_1
-            ) / (self.UPPER_BOUND_REGION_2 - self.UPPER_BOUND_REGION_1)
-        elif self.UPPER_BOUND_REGION_2 < speed <= self.UPPER_BOUND_REGION_3:
-            coeff = self.COEFF_REGION_2 + (speed - self.UPPER_BOUND_REGION_2) * (
-                self.COEFF_REGION_3 - self.COEFF_REGION_2
-            ) / (self.UPPER_BOUND_REGION_3 - self.UPPER_BOUND_REGION_2)
-        elif speed > self.UPPER_BOUND_REGION_3:
-            coeff = self.COEFF_REGION_3
-        else:
-            raise ValueError("This should never happen!")
+            return self.VERY_LARGE_COEFF
 
-        return coeff
+        sorted_speeds = sorted(self.SPEEDS_TO_PARAM_MAPPING.keys())
+
+        if speed <= sorted_speeds[0]:
+            param_at_speed = self.SPEEDS_TO_PARAM_MAPPING[sorted_speeds[0]]
+        elif speed >= sorted_speeds[-1]:
+            param_at_speed = self.SPEEDS_TO_PARAM_MAPPING[sorted_speeds[-1]]
+        else:
+            for i in range(len(sorted_speeds) - 1):
+                if sorted_speeds[i] <= speed <= sorted_speeds[i + 1]:
+                    lower_speed = sorted_speeds[i]
+                    upper_speed = sorted_speeds[i + 1]
+                    lower_param = self.SPEEDS_TO_PARAM_MAPPING[lower_speed]
+                    upper_param = self.SPEEDS_TO_PARAM_MAPPING[upper_speed]
+                    weight = (speed - lower_speed) / (upper_speed - lower_speed)
+                    param_at_speed = lower_param * (1 - weight) + upper_param * weight
+                    break
+
+        return param_at_speed * speed
 
     def compute_radius_from_steering_command(
         self, cmd_steering: float, speed: float
@@ -219,35 +222,39 @@ class CarModelBicycleV2(CarModelBicyclePure):
             return self.VERY_LARGE_RADIUS
         else:
             coeff = self._compute_coefficient(speed)
-            radius = (
-                STEERING_DIRECTION_FACTOR * coeff / (cmd_steering - STEERING_IDLE_PWM)
-            )
-            return radius
+            steering_diff = cmd_steering - STEERING_IDLE_PWM
+            return STEERING_DIRECTION_FACTOR * coeff / steering_diff
 
     def compute_steering_command_from_radius(
         self, radius: float, speed: float
     ) -> float:
         """Obtained by inversing the compute_radius_from_steering_command function."""
-        if abs(radius) < 1e-3:
+        if abs(radius) < 0.1:
             return STEERING_IDLE_PWM
         else:
             coeff = self._compute_coefficient(speed)
             return STEERING_IDLE_PWM + STEERING_DIRECTION_FACTOR * (coeff / radius)
 
 
-class CarModelBicycleV3(CarModelBicycleV2):
-    """Models the car behavior as a kinematic bicycle model.
-
-    The model assumes that the car is moving in a circular path, with a constant radius determined by the steering command,
-    with the second attempt at parameter fitting (Oct 2025), i.e. the V3 model.
-
-    UNTESTED for now, will be tested once we have the simulator
-    TODO later: try to unify the V2 and V3 with a base class called region-based
+class CarModelBicycleV2(CarModelBicycleSpeedToParam):
+    """
+    These are the params from the first attempt at parameter fitting (2023-2024), i.e. the V2 model.
+    They were estimated from steady-state circle fitting, using scripts in the folder steering_param_identification_old
     """
 
-    SPEEDS_TO_COEFF_MAPPING = {
-        # mapping of the coeff associated with each speed region, for the San Mateo 2025-07-20 bags
-        # TODO modify the logic to use the center of the region
+    SPEEDS_TO_PARAM_MAPPING: dict = {  # here, params were computed as: steering_diff * radius of circle at the given speed
+        1.5: 27 * 1.25,
+        5: 24 * 2.3,
+        8: 26 * 4,
+    }
+
+
+class CarModelBicycleV3(CarModelBicycleSpeedToParam):
+    """
+    Similar to V2, but with updated params based on the 2025-07-20 San Mateo bagfiles (still steady-state circle fitting)
+    """
+
+    SPEEDS_TO_PARAM_MAPPING: dict = {
         2: 12.67852795,
         3: 12.29078091,
         4: 10.12400495,
@@ -255,40 +262,3 @@ class CarModelBicycleV3(CarModelBicycleV2):
         6: 9.55109679,
         7: 10.15111903,
     }
-
-    def _compute_coefficient(self, speed: float) -> float:
-        """Compute the coefficient used to compute the required turning radius, see model description for more details."""
-
-        if speed < 0:
-            raise ValueError("Speed cannot be negative!")
-        if speed == 0:
-            coeff = self.VERY_LARGE_COEFF
-        else:  # NOTE not very efficient, let's see if we can do better
-            # Get sorted speeds from the mapping
-            sorted_speeds = sorted(self.SPEEDS_TO_COEFF_MAPPING.keys())
-
-            # If speed is below the minimum, use the minimum speed's coefficient
-            if speed <= sorted_speeds[0]:
-                coeff = self.SPEEDS_TO_COEFF_MAPPING[sorted_speeds[0]] * speed
-            # If speed is above the maximum, use the maximum speed's coefficient
-            elif speed >= sorted_speeds[-1]:
-                coeff = self.SPEEDS_TO_COEFF_MAPPING[sorted_speeds[-1]] * speed
-            else:
-                # Find the two speeds that bound the current speed
-                for i in range(len(sorted_speeds) - 1):
-                    if sorted_speeds[i] <= speed <= sorted_speeds[i + 1]:
-                        lower_speed = sorted_speeds[i]
-                        upper_speed = sorted_speeds[i + 1]
-
-                        # Compute weighted average between the two coefficients
-                        lower_coeff = self.SPEEDS_TO_COEFF_MAPPING[lower_speed]
-                        upper_coeff = self.SPEEDS_TO_COEFF_MAPPING[upper_speed]
-
-                        # Weight factor: 0 means use lower_coeff, 1 means use upper_coeff
-                        weight = (speed - lower_speed) / (upper_speed - lower_speed)
-                        coeff = (
-                            lower_coeff * (1 - weight) + upper_coeff * weight
-                        ) * speed
-                        break
-
-        return coeff

--- a/autonomy_software/vehicle_models_pkg/src/vehicle_models_pkg/vehicle_models.py
+++ b/autonomy_software/vehicle_models_pkg/src/vehicle_models_pkg/vehicle_models.py
@@ -242,6 +242,7 @@ class CarModelBicycleV2(CarModelBicycleSpeedToParam):
     """
     These are the params from the first attempt at parameter fitting (2023-2024), i.e. the V2 model.
     They were estimated from steady-state circle fitting, using scripts in the folder steering_param_identification_old
+    The bags were from the Shoreline parking lot testing session
     """
 
     SPEEDS_TO_PARAM_MAPPING: dict = {

--- a/utils/performance_analysis/bagfile_loader.py
+++ b/utils/performance_analysis/bagfile_loader.py
@@ -163,8 +163,8 @@ class BagfileLoader:
         else:
             self.waypoints = None
 
-        # Align all msgs to the GPS timestamps
-        for gps_msg_time in gps_timestamps:
+        # Align all msgs to the GPS timestamps (we leave out the last GPS message in case the stack was stopped right after a GPS message)
+        for gps_msg_time in gps_timestamps[:-1]:
 
             # Find the closest pose timestamp
             closest_pose_time = [ts for ts in pose_timestamps if ts >= gps_msg_time][0]

--- a/utils/performance_analysis/replay_lateral_models.py
+++ b/utils/performance_analysis/replay_lateral_models.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=too-many-lines
 """
 Replay lateral control with different vehicle models.
 
@@ -33,6 +34,8 @@ from vehicle_models_pkg.vehicle_models import (
     CarModelBicycleV1,
     CarModelBicycleV2,
     CarModelBicycleV3,
+    CarModelBicycleV3B,
+    CarModelBicycleV4,
 )
 from vehicle_models_pkg.vehicle_models_constants import (
     STEERING_IDLE_PWM,
@@ -41,11 +44,13 @@ from vehicle_models_pkg.vehicle_models_constants import (
 )
 
 
-MODEL_REGISTRY: Dict[str, type] = {
+MODEL_REGISTRY = {
     "V0": CarModelBicycleV0,
     "V1": CarModelBicycleV1,
     "V2": CarModelBicycleV2,
     "V3": CarModelBicycleV3,
+    "V3B": CarModelBicycleV3B,
+    "V4": CarModelBicycleV4,
 }
 
 MODEL_COLORS = {
@@ -53,6 +58,8 @@ MODEL_COLORS = {
     "V1": "green",
     "V2": "dodgerblue",
     "V3": "mediumpurple",
+    "V3B": "purple",
+    "V4": "crimson",
 }
 
 
@@ -274,6 +281,75 @@ def print_summary(
                 print(
                     f"    Yaw |offset| (max):         {np.max(np.abs(yaw_deg)):.2f} deg"
                 )
+
+        # --- Speed-stratified metrics ---
+        if name in model_offsets:
+            offsets, speeds = model_offsets[name]
+            speed_bins = [(0, 2), (2, 4), (4, 6), (6, float("inf"))]
+            bin_results = []
+            for lo, hi in speed_bins:
+                mask = (~np.isnan(offsets)) & (speeds >= lo) & (speeds < hi)
+                if np.any(mask):
+                    rms = np.sqrt(np.mean(offsets[mask] ** 2))
+                    bin_results.append((lo, hi, np.sum(mask), rms))
+            if bin_results:
+                print("    --- Speed-stratified offset (RMS) ---")
+                for lo, hi, n, rms in bin_results:
+                    hi_str = f"{hi:.0f}" if hi != float("inf") else "+"
+                    label = f"{lo:.0f}-{hi_str} m/s"
+                    print(f"      {label:>10s}: {rms:.4f} m  (n={n})")
+
+        # --- Transient vs steady-state split ---
+        if name in model_offsets:
+            offsets, speeds = model_offsets[name]
+            steering_cmds = np.array([r.steering_cmd for r in sorted_records])
+            times = np.array([r.gps_msg_time for r in sorted_records])
+            is_transient = np.zeros(len(sorted_records), dtype=bool)
+            for i in range(len(sorted_records)):
+                window_mask = (times >= times[i] - 0.5) & (times <= times[i])
+                if np.any(window_mask):
+                    cmd_range = np.max(steering_cmds[window_mask]) - np.min(
+                        steering_cmds[window_mask]
+                    )
+                    is_transient[i] = cmd_range > 2.0
+
+            valid = ~np.isnan(offsets)
+            steady_mask = valid & ~is_transient
+            trans_mask = valid & is_transient
+            if np.any(steady_mask) or np.any(trans_mask):
+                print("    --- Transient vs steady-state offset ---")
+                if np.any(steady_mask):
+                    rms_ss = np.sqrt(np.mean(offsets[steady_mask] ** 2))
+                    print(
+                        f"      Steady-state: {rms_ss:.4f} m RMS  (n={np.sum(steady_mask)})"
+                    )
+                if np.any(trans_mask):
+                    rms_tr = np.sqrt(np.mean(offsets[trans_mask] ** 2))
+                    print(
+                        f"      Transient:    {rms_tr:.4f} m RMS  (n={np.sum(trans_mask)})"
+                    )
+
+        # --- Left/right asymmetry ---
+        if name in model_offsets:
+            offsets, speeds = model_offsets[name]
+            steering_cmds = np.array([r.steering_cmd for r in sorted_records])
+            valid = ~np.isnan(offsets)
+            left_mask = valid & (steering_cmds < STEERING_IDLE_PWM)
+            right_mask = valid & (steering_cmds > STEERING_IDLE_PWM)
+            if np.any(left_mask) or np.any(right_mask):
+                print("    --- Left/right steering asymmetry ---")
+                if np.any(left_mask):
+                    mean_l = np.mean(offsets[left_mask])
+                    rms_l = np.sqrt(np.mean(offsets[left_mask] ** 2))
+                    print(
+                        f"      Left  (cmd<{STEERING_IDLE_PWM}): mean={mean_l:+.4f} m, RMS={rms_l:.4f} m  (n={np.sum(left_mask)})"
+                    )
+                if np.any(right_mask):
+                    mean_r = np.mean(offsets[right_mask])
+                    rms_r = np.sqrt(np.mean(offsets[right_mask] ** 2))
+                    print(
+                        f"      Right (cmd>{STEERING_IDLE_PWM}): mean={mean_r:+.4f} m, RMS={rms_r:.4f} m  (n={np.sum(right_mask)})"
+                    )
 
     print("=============================================\n")
 
@@ -836,9 +912,9 @@ def main():
     parser.add_argument(
         "--models",
         nargs="+",
-        default=["V0", "V3"],
+        default=["V0", "V3", "V3B"],
         choices=list(MODEL_REGISTRY.keys()),
-        help="Which models to compare (default: V0 V3)",
+        help="Which models to compare (default: V0 V3 V3B)",
     )
     parser.add_argument(
         "--simulate",

--- a/utils/steering_param_identification/permanent_regime_circle_fitter.py
+++ b/utils/steering_param_identification/permanent_regime_circle_fitter.py
@@ -10,9 +10,15 @@ import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 from geometry_utils_pkg.geometry_utils import fit_circle_to_points
-from performance_analysis.bagfile_loader import BagfileLoader
 from plotly.subplots import make_subplots
-from vehicle_models_pkg.vehicle_models_constants import (
+
+
+# Add performance_analysis to path so we can import bagfile_loader, HACK...
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_SCRIPT_DIR, "..", "performance_analysis"))
+
+from bagfile_loader import BagfileLoader  # noqa: E402
+from vehicle_models_pkg.vehicle_models_constants import (  # noqa: E402
     MAX_STEERING_FBK,
     MIN_STEERING_FBK,
     STEERING_MAX_PWM,

--- a/utils/steering_param_identification/permanent_regime_circle_fitter.py
+++ b/utils/steering_param_identification/permanent_regime_circle_fitter.py
@@ -9,8 +9,8 @@ from typing import List
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
-from geometry_utils_pkg.bagfile_loader import BagfileLoader
 from geometry_utils_pkg.geometry_utils import fit_circle_to_points
+from performance_analysis.bagfile_loader import BagfileLoader
 from plotly.subplots import make_subplots
 from vehicle_models_pkg.vehicle_models_constants import (
     MAX_STEERING_FBK,

--- a/utils/steering_param_identification/permanent_regime_steering_params_identification.py
+++ b/utils/steering_param_identification/permanent_regime_steering_params_identification.py
@@ -412,10 +412,10 @@ if __name__ == "__main__":
         help="Path to the CSV file from permanent_regime_circle_fitter.py",
     )
     parser.add_argument(
-        "--plot-basics",
+        "--no-plot-basics",
         action="store_true",
-        default=True,
-        help="Plot basic information about the CSV data (default: True)",
+        default=False,
+        help="Do not plot basic information about the CSV data (default: False)",
     )
     parser.add_argument(
         "--plot-individual-fits",
@@ -428,6 +428,6 @@ if __name__ == "__main__":
 
     main(
         csv_path=args.csv_path,
-        plot_basics=args.plot_basics,
+        plot_basics=not args.no_plot_basics,
         plot_individual_fits=args.plot_individual_fits,
     )

--- a/utils/steering_param_identification/trajectory_based_identification.py
+++ b/utils/steering_param_identification/trajectory_based_identification.py
@@ -17,13 +17,15 @@ computed via one-step forward simulation against recorded GPS positions.
 Usage:
     python trajectory_based_identification.py \
         --bag-paths bag1.bag bag2.bag \
-        --speeds 2 3 4 5 6 7
+        --speeds 2 3 4 5 6 7 \
+        --base-model V3
 
     # Use a held-out bag for validation:
     python trajectory_based_identification.py \
         --bag-paths train1.bag train2.bag \
         --validation-bag-path val.bag \
-        --speeds 2 3 4 5 6 7
+        --speeds 2 3 4 5 6 7 \
+        --base-model V3 \
 """
 
 import argparse

--- a/utils/steering_param_identification/trajectory_based_identification.py
+++ b/utils/steering_param_identification/trajectory_based_identification.py
@@ -1,0 +1,511 @@
+#!/usr/bin/env python3
+"""
+Trajectory-based parameter identification for the kinematic bicycle model.
+
+Instead of fitting parameters from steady-state circle data only, this script
+optimizes the speed-to-coefficient mapping by minimizing one-step prediction
+error directly on bag file trajectories.
+
+The model being optimized follows the CarModelBicycleSpeedToParam structure:
+    radius = STEERING_DIRECTION_FACTOR * param(speed) * speed / (cmd_steering - STEERING_IDLE_PWM)
+where param(speed) is linearly interpolated from a set of (speed, param) pairs.
+
+The optimizer finds the coefficient values that minimize:
+    cost = mean(lateral_offset^2) + yaw_weight * mean(yaw_offset^2)
+computed via one-step forward simulation against recorded GPS positions.
+
+Usage:
+    python trajectory_based_identification.py \
+        --bag-paths bag1.bag bag2.bag \
+        --speeds 2 3 4 5 6 7
+
+    # Use a held-out bag for validation:
+    python trajectory_based_identification.py \
+        --bag-paths train1.bag train2.bag \
+        --validation-bag-path val.bag \
+        --speeds 2 3 4 5 6 7
+"""
+
+import argparse
+import os
+import sys
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+from scipy.optimize import differential_evolution
+
+
+# Add performance_analysis to path so we can import its modules
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PERF_ANALYSIS_DIR = os.path.join(SCRIPT_DIR, "..", "performance_analysis")
+sys.path.insert(0, PERF_ANALYSIS_DIR)
+
+from analysis_utils import trim_records  # noqa: E402
+from bagfile_loader import BagfileLoader, BagfileRecord  # noqa: E402
+from geometry_utils_pkg.geometry_utils import wrap_angle  # noqa: E402
+from vehicle_models_pkg.vehicle_models import (  # noqa: E402
+    CarModelBicyclePure,
+    CarModelBicycleSpeedToParam,
+    CarModelBicycleV2,
+    CarModelBicycleV3,
+    CarModelBicycleV4,
+)
+from vehicle_models_pkg.vehicle_models_constants import STEERING_IDLE_PWM  # noqa: E402
+
+
+BASE_MODEL_REGISTRY: Dict[str, type] = {
+    "V2": CarModelBicycleV2,
+    "V3": CarModelBicycleV3,
+    "V4": CarModelBicycleV4,
+}
+
+DEFAULT_PARAM_VALUE = (
+    10.0  # Default param value for speeds not in the base model mapping (for bounds)
+)
+
+
+# ---------------------------------------------------------------------------
+# Parameterized model: SpeedToParam-based with injectable coefficients
+# ---------------------------------------------------------------------------
+class CarModelParameterized(CarModelBicycleSpeedToParam):
+    """A SpeedToParam model whose mapping can be set externally."""
+
+    def __init__(self, speeds_to_param: Dict[float, float]) -> None:
+        super().__init__()
+        self.SPEEDS_TO_PARAM_MAPPING = dict(speeds_to_param)
+
+
+# ---------------------------------------------------------------------------
+# One-step cost computation (reuses the same logic as replay_lateral_models.py)
+# ---------------------------------------------------------------------------
+def compute_one_step_cost(
+    sorted_records: List[BagfileRecord],
+    model: CarModelBicyclePure,
+    yaw_weight: float = 1.0,
+    min_speed: float = 0.5,
+) -> Tuple[float, Dict[str, float]]:
+    """
+    Run one-step forward simulation and return the cost (mean squared lateral
+    offset + yaw_weight * mean squared yaw offset).
+
+    Also returns a dict of diagnostic metrics.
+
+    Records with speed below min_speed are skipped (near-stationary data is
+    noisy and uninformative for steering identification).
+    """
+    lateral_sq_sum = 0.0
+    yaw_sq_sum = 0.0
+    n = 0
+
+    for i in range(len(sorted_records) - 1):
+        r = sorted_records[i]
+        r_next = sorted_records[i + 1]
+
+        # Skip low-speed records
+        if r.state.vx < min_speed:
+            continue
+        # Skip records where steering is at idle (going straight, nothing to fit)
+        if r.steering_cmd == STEERING_IDLE_PWM:
+            continue
+
+        dt = r_next.gps_msg_time - r.gps_msg_time
+        if dt <= 0:
+            continue
+
+        # One-step: init at current GPS, step once, compare with next GPS
+        model.states.clear()
+        model.init(x=r.state.x, y=r.state.y, vx=r.state.vx, angle=r.state.angle)
+        model.step(dt=dt, cmd_steering=r.steering_cmd)
+
+        pred = model.states[-1]
+
+        # Lateral offset (signed, same convention as replay_lateral_models.py)
+        dx = pred.x - r_next.state.x
+        dy = pred.y - r_next.state.y
+
+        lateral_sq_sum += dx**2 + dy**2
+
+        # Yaw offset
+        yaw_err = wrap_angle(pred.angle - r_next.state.angle)
+        yaw_sq_sum += yaw_err**2
+
+        n += 1
+
+    if n == 0:
+        return float("inf"), {
+            "n": 0,
+            "rms_offset_m": float("nan"),
+            "rms_yaw_deg": float("nan"),
+        }
+
+    mean_lateral_sq = lateral_sq_sum / n
+    mean_yaw_sq = yaw_sq_sum / n
+
+    cost = mean_lateral_sq + yaw_weight * mean_yaw_sq
+
+    metrics = {
+        "n": n,
+        "rms_offset_m": np.sqrt(mean_lateral_sq),
+        "rms_yaw_deg": np.degrees(np.sqrt(mean_yaw_sq)),
+    }
+    return cost, metrics
+
+
+# ---------------------------------------------------------------------------
+# Load and prepare records from a bag file
+# ---------------------------------------------------------------------------
+def load_sorted_records(
+    bag_path: str,
+    start: Optional[float] = None,
+    end: Optional[float] = None,
+) -> List[BagfileRecord]:
+    """Load a bag file and return sorted, optionally trimmed records."""
+    loader = BagfileLoader(bag_path)
+    records = loader.bagfile_records_dicts
+    if len(records) < 2:
+        raise ValueError(f"Not enough records in {bag_path}")
+
+    trimmed, _ = trim_records(records, start, end)
+    sorted_records = sorted(trimmed.values(), key=lambda r: r.gps_msg_time)
+    return sorted_records
+
+
+# ---------------------------------------------------------------------------
+# Objective function for the optimizer
+# ---------------------------------------------------------------------------
+def make_objective(
+    all_sorted_records: List[List[BagfileRecord]],
+    speeds: List[float],
+    yaw_weight: float,
+    min_speed: float,
+):
+    """
+    Return a callable objective(coeffs) -> cost for use with scipy optimizers.
+
+    coeffs is a 1-D array of length len(speeds), one coefficient per speed point.
+    """
+
+    def objective(coeffs: np.ndarray) -> float:
+        mapping = dict(zip(speeds, coeffs))
+        total_cost = 0.0
+        total_n = 0
+        for sorted_records in all_sorted_records:
+            model = CarModelParameterized(mapping)
+            cost, metrics = compute_one_step_cost(
+                sorted_records, model, yaw_weight=yaw_weight, min_speed=min_speed
+            )
+            n = metrics["n"]
+            if n > 0:
+                total_cost += cost * n
+                total_n += n
+
+        if total_n == 0:
+            return float("inf")
+        return total_cost / total_n
+
+    return objective
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main():
+    parser = argparse.ArgumentParser(
+        description="Trajectory-based parameter identification for the kinematic bicycle model."
+    )
+    parser.add_argument(
+        "--bag-paths",
+        nargs="+",
+        required=True,
+        help="Path(s) to training bag file(s) or folder(s) containing .bag files",
+    )
+    parser.add_argument(
+        "--validation-bag-path",
+        type=str,
+        default=None,
+        help="Optional held-out bag file for validation",
+    )
+    parser.add_argument(
+        "--base-model",
+        type=str,
+        required=True,
+        choices=list(BASE_MODEL_REGISTRY.keys()),
+        help="Base model to use for baseline comparison and initial bounds",
+    )
+    parser.add_argument(
+        "--speeds",
+        nargs="+",
+        type=float,
+        default=None,
+        help="Speed points for the coefficient mapping (default: taken from base model)",
+    )
+    parser.add_argument(
+        "--yaw-weight",
+        type=float,
+        default=1.0,
+        help="Weight for yaw error in cost function (default: 1.0)",
+    )
+    parser.add_argument(
+        "--min-speed",
+        type=float,
+        default=0.5,
+        help="Minimum speed to include in optimization (default: 0.5 m/s)",
+    )
+    parser.add_argument(
+        "--start",
+        type=float,
+        default=None,
+        help="Start time in seconds from bag start (trim earlier data)",
+    )
+    parser.add_argument(
+        "--end",
+        type=float,
+        default=None,
+        help="End time in seconds from bag start (trim later data)",
+    )
+    parser.add_argument(
+        "--maxiter",
+        type=int,
+        default=100,
+        help="Maximum iterations for differential_evolution (default: 100)",
+    )
+    args = parser.parse_args()
+
+    # Resolve base model
+    base_model_class = BASE_MODEL_REGISTRY[args.base_model]
+    base_model_name = args.base_model
+
+    # Default speeds from the base model's mapping if not provided
+    if args.speeds is None:
+        args.speeds = sorted(base_model_class.SPEEDS_TO_PARAM_MAPPING.keys())
+    # Validate that the base model has params for the requested speeds (for bounds)
+    for s in args.speeds:
+        if s not in base_model_class.SPEEDS_TO_PARAM_MAPPING:
+            print(
+                f"WARNING: speed {s} not in {base_model_name}.SPEEDS_TO_PARAM_MAPPING "
+                f"(available: {sorted(base_model_class.SPEEDS_TO_PARAM_MAPPING.keys())}). "
+                f"Using default bound center of {DEFAULT_PARAM_VALUE}."
+            )
+
+    # Resolve bag paths: expand directories to their .bag files
+    resolved_bag_paths = []
+    for path in args.bag_paths:
+        if os.path.isdir(path):
+            bag_files = sorted(
+                os.path.join(path, f) for f in os.listdir(path) if f.endswith(".bag")
+            )
+            if not bag_files:
+                print(f"Warning: no .bag files found in {path}")
+            resolved_bag_paths.extend(bag_files)
+        else:
+            resolved_bag_paths.append(path)
+    args.bag_paths = resolved_bag_paths
+
+    if not args.bag_paths:
+        print("Error: no bag files to process.")
+        return
+
+    if len(args.bag_paths) > 1 and (args.start is not None or args.end is not None):
+        print(
+            "WARNING: --start/--end will be applied identically to all bag files. "
+            "This is probably not what you want when using multiple bags."
+        )
+
+    # Load all training bags
+    print(f"Loading {len(args.bag_paths)} training bag file(s)...")
+    all_sorted_records = []
+    for bag_path in args.bag_paths:
+        print(f"  Loading {os.path.basename(bag_path)}...")
+        records = load_sorted_records(bag_path, args.start, args.end)
+        print(f"    {len(records)} records")
+        all_sorted_records.append(records)
+
+    # Print datapoint counts per speed region
+    print(
+        f"\n  Datapoints per speed region (min_speed={args.min_speed} m/s, excluding idle steering):"
+    )
+    speeds_sorted = sorted(args.speeds)
+    # Regions: [min_speed, speeds[0]], [speeds[0], speeds[1]], ..., [speeds[-1], +inf)
+    region_edges = [args.min_speed] + speeds_sorted + [float("inf")]
+    all_records_flat = [r for records in all_sorted_records for r in records]
+    usable = [
+        r
+        for r in all_records_flat
+        if r.state.vx >= args.min_speed and r.steering_cmd != STEERING_IDLE_PWM
+    ]
+    for i in range(len(region_edges) - 1):
+        lo, hi = region_edges[i], region_edges[i + 1]
+        count = sum(1 for r in usable if lo <= r.state.vx < hi)
+        hi_str = f"{hi:.1f}" if hi != float("inf") else "+"
+        print(f"    [{lo:.1f}, {hi_str}) m/s: {count} datapoints")
+    print(f"    Total usable: {len(usable)}")
+
+    # Load validation bag if provided
+    val_records = None
+    if args.validation_bag_path:
+        print(f"  Loading validation: {os.path.basename(args.validation_bag_path)}...")
+        val_records = load_sorted_records(
+            args.validation_bag_path, args.start, args.end
+        )
+        print(f"    {len(val_records)} records")
+
+    # Evaluate baseline before optimization
+    print(f"\n===== {base_model_name} BASELINE =====")
+    baseline_model = base_model_class()
+    for i, (bag_path, sorted_records) in enumerate(
+        zip(args.bag_paths, all_sorted_records)
+    ):
+        _, metrics = compute_one_step_cost(
+            sorted_records,
+            baseline_model,
+            yaw_weight=args.yaw_weight,
+            min_speed=args.min_speed,
+        )
+        print(
+            f"  {os.path.basename(bag_path)}: "
+            f"RMS offset={metrics['rms_offset_m']:.4f} m, "
+            f"RMS yaw={metrics['rms_yaw_deg']:.2f} deg  "
+            f"(n={metrics['n']})"
+        )
+    if val_records:
+        _, metrics = compute_one_step_cost(
+            val_records,
+            baseline_model,
+            yaw_weight=args.yaw_weight,
+            min_speed=args.min_speed,
+        )
+        print(
+            f"  [VAL] {os.path.basename(args.validation_bag_path)}: "
+            f"RMS offset={metrics['rms_offset_m']:.4f} m, "
+            f"RMS yaw={metrics['rms_yaw_deg']:.2f} deg  "
+            f"(n={metrics['n']})"
+        )
+
+    # Run optimization
+    print("\n===== OPTIMIZATION =====")
+    print(f"  Speed points: {args.speeds}")
+    print(f"  Yaw weight: {args.yaw_weight}")
+    print(f"  Min speed: {args.min_speed} m/s")
+    print(f"  Training bags: {len(all_sorted_records)}")
+
+    # Use base model's params as initial reference for bounds
+    base_params = [
+        base_model_class.SPEEDS_TO_PARAM_MAPPING[s]
+        if s in base_model_class.SPEEDS_TO_PARAM_MAPPING
+        else DEFAULT_PARAM_VALUE
+        for s in args.speeds
+    ]
+    # Bounds: allow params to vary between 0.2x and 5x the base model value
+    bounds = [(p * 0.2, p * 5.0) for p in base_params]
+
+    objective = make_objective(
+        all_sorted_records, args.speeds, args.yaw_weight, args.min_speed
+    )
+
+    print("  Running differential_evolution...")
+    result = differential_evolution(
+        objective,
+        bounds=bounds,
+        maxiter=args.maxiter,
+        seed=42,
+        tol=1e-8,
+        disp=True,
+        polish=True,
+    )
+
+    optimized_params = result.x
+    optimized_mapping = dict(zip(args.speeds, optimized_params))
+
+    print("\n===== RESULTS =====")
+    print(f"  Optimizer success: {result.success}")
+    print(f"  Optimizer message: {result.message}")
+    print(f"  Final cost: {result.fun:.8f}")
+    print()
+    print("  Optimized SPEEDS_TO_PARAM_MAPPING:")
+    print("  {")
+    for s, p in sorted(optimized_mapping.items()):
+        base_p = base_model_class.SPEEDS_TO_PARAM_MAPPING.get(s, None)
+        delta_str = ""
+        if base_p is not None:
+            delta_pct = (p - base_p) / base_p * 100
+            delta_str = f"  # {base_model_name}: {base_p:.2f}  ({delta_pct:+.1f}%)"
+        print(f"      {s}: {p:.2f},{delta_str}")
+    print("  }")
+
+    # Evaluate optimized model on training data
+    print("\n===== OPTIMIZED MODEL EVALUATION =====")
+    opt_model = CarModelParameterized(optimized_mapping)
+    for i, (bag_path, sorted_records) in enumerate(
+        zip(args.bag_paths, all_sorted_records)
+    ):
+        _, metrics = compute_one_step_cost(
+            sorted_records,
+            opt_model,
+            yaw_weight=args.yaw_weight,
+            min_speed=args.min_speed,
+        )
+        # Also get baseline for comparison
+        _, base_metrics = compute_one_step_cost(
+            sorted_records,
+            base_model_class(),
+            yaw_weight=args.yaw_weight,
+            min_speed=args.min_speed,
+        )
+        print(f"  {os.path.basename(bag_path)}:")
+        print(
+            f"    {base_model_name}:        RMS offset={base_metrics['rms_offset_m']:.4f} m, "
+            f"RMS yaw={base_metrics['rms_yaw_deg']:.2f} deg"
+        )
+        print(
+            f"    Optimized: RMS offset={metrics['rms_offset_m']:.4f} m, "
+            f"RMS yaw={metrics['rms_yaw_deg']:.2f} deg"
+        )
+        offset_improv = (
+            (1 - metrics["rms_offset_m"] / base_metrics["rms_offset_m"]) * 100
+            if base_metrics["rms_offset_m"] > 0
+            else 0
+        )
+        yaw_improv = (
+            (1 - metrics["rms_yaw_deg"] / base_metrics["rms_yaw_deg"]) * 100
+            if base_metrics["rms_yaw_deg"] > 0
+            else 0
+        )
+        print(f"    Improvement: offset {offset_improv:+.1f}%, yaw {yaw_improv:+.1f}%")
+
+    # Evaluate on validation bag
+    if val_records:
+        _, metrics = compute_one_step_cost(
+            val_records, opt_model, yaw_weight=args.yaw_weight, min_speed=args.min_speed
+        )
+        _, base_metrics = compute_one_step_cost(
+            val_records,
+            base_model_class(),
+            yaw_weight=args.yaw_weight,
+            min_speed=args.min_speed,
+        )
+        print(f"\n  [VALIDATION] {os.path.basename(args.validation_bag_path)}:")
+        print(
+            f"    {base_model_name}:        RMS offset={base_metrics['rms_offset_m']:.4f} m, "
+            f"RMS yaw={base_metrics['rms_yaw_deg']:.2f} deg"
+        )
+        print(
+            f"    Optimized: RMS offset={metrics['rms_offset_m']:.4f} m, "
+            f"RMS yaw={metrics['rms_yaw_deg']:.2f} deg"
+        )
+        offset_improv = (
+            (1 - metrics["rms_offset_m"] / base_metrics["rms_offset_m"]) * 100
+            if base_metrics["rms_offset_m"] > 0
+            else 0
+        )
+        yaw_improv = (
+            (1 - metrics["rms_yaw_deg"] / base_metrics["rms_yaw_deg"]) * 100
+            if base_metrics["rms_yaw_deg"] > 0
+            else 0
+        )
+        print(f"    Improvement: offset {offset_improv:+.1f}%, yaw {yaw_improv:+.1f}%")
+
+    print("\n===== DONE =====")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/steering_param_identification/trajectory_based_identification.py
+++ b/utils/steering_param_identification/trajectory_based_identification.py
@@ -11,7 +11,7 @@ The model being optimized follows the CarModelBicycleSpeedToParam structure:
 where param(speed) is linearly interpolated from a set of (speed, param) pairs.
 
 The optimizer finds the coefficient values that minimize:
-    cost = mean(lateral_offset^2) + yaw_weight * mean(yaw_offset^2)
+    cost = mean(position_error^2) + yaw_weight * mean(yaw_error^2)
 computed via one-step forward simulation against recorded GPS positions.
 
 Usage:
@@ -87,15 +87,15 @@ def compute_one_step_cost(
     min_speed: float = 0.5,
 ) -> Tuple[float, Dict[str, float]]:
     """
-    Run one-step forward simulation and return the cost (mean squared lateral
-    offset + yaw_weight * mean squared yaw offset).
+    Run one-step forward simulation and return the cost (mean squared position
+    error + yaw_weight * mean squared yaw error).
 
     Also returns a dict of diagnostic metrics.
 
     Records with speed below min_speed are skipped (near-stationary data is
     noisy and uninformative for steering identification).
     """
-    lateral_sq_sum = 0.0
+    position_sq_sum = 0.0
     yaw_sq_sum = 0.0
     n = 0
 
@@ -121,11 +121,11 @@ def compute_one_step_cost(
 
         pred = model.states[-1]
 
-        # Lateral offset (signed, same convention as replay_lateral_models.py)
+        # Squared Euclidean position error
         dx = pred.x - r_next.state.x
         dy = pred.y - r_next.state.y
 
-        lateral_sq_sum += dx**2 + dy**2
+        position_sq_sum += dx**2 + dy**2
 
         # Yaw offset
         yaw_err = wrap_angle(pred.angle - r_next.state.angle)
@@ -140,14 +140,14 @@ def compute_one_step_cost(
             "rms_yaw_deg": float("nan"),
         }
 
-    mean_lateral_sq = lateral_sq_sum / n
+    mean_position_sq = position_sq_sum / n
     mean_yaw_sq = yaw_sq_sum / n
 
-    cost = mean_lateral_sq + yaw_weight * mean_yaw_sq
+    cost = mean_position_sq + yaw_weight * mean_yaw_sq
 
     metrics = {
         "n": n,
-        "rms_offset_m": np.sqrt(mean_lateral_sq),
+        "rms_offset_m": np.sqrt(mean_position_sq),
         "rms_yaw_deg": np.degrees(np.sqrt(mean_yaw_sq)),
     }
     return cost, metrics

--- a/utils/steering_param_identification/trajectory_based_identification.py
+++ b/utils/steering_param_identification/trajectory_based_identification.py
@@ -37,7 +37,7 @@ import numpy as np
 from scipy.optimize import differential_evolution
 
 
-# Add performance_analysis to path so we can import its modules
+# Add performance_analysis to path so we can import its modules, HACK...
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 PERF_ANALYSIS_DIR = os.path.join(SCRIPT_DIR, "..", "performance_analysis")
 sys.path.insert(0, PERF_ANALYSIS_DIR)


### PR DESCRIPTION
- Unifying the logic of the V2 and V3 models, so that we can easily create many models with different params for the different speed regions.
- new script `utils/steering_param_identification/trajectory_based_identification.py` that performs optimization of the params in a way that minimizes the prediction error (it differs from `utils/steering_param_identification/permanent_regime_steering_params_identification.py` because the latter does the optimization on the radius, not on the predicted postion). HOWEVER this new technique is very sensitive to errors on the yaw_angle of the vehicle, and as we know the yaw_angle that we get from the GPS's course_over_ground is very off. So the resulting model is not good.
- Added more metrics in `utils/performance_analysis/replay_lateral_models.py`
- Adding logic to do delay compensation in the lateral_controller: optionally predict the future position of the vehicle and do the `steering_command` computation at the predicted future position. We will need to test it on the vehicle to know if it helps.

So now we have the following models:
- V2: parameters computed with scripts from `steering_param_identification_old` on the bags from the Shoreline testing session (don't remember the date...)
- V3: parameters computed with scripts from `steering_param_identification` on the bags from the College of San Mateo testing session (2025-07-20)
- V3B: parameters computed with scripts from `steering_param_identification` on the bags from the Cañada College testing session (2025-08-24)
- V4: parameters computed with script `trajectory_based_identification.py ` on  the bags from the Cañada College testing session (2025-08-24). BUT: as discussed above, likely bad performance

My conclusion at this state: until we have better yaw_angle estimation, there is little/no point trying to build better vehicle models...